### PR TITLE
Bug fix petname

### DIFF
--- a/src/main/java/seedu/address/model/pet/Address.java
+++ b/src/main/java/seedu/address/model/pet/Address.java
@@ -27,7 +27,7 @@ public class Address {
     public Address(String address) {
         requireNonNull(address);
         checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
-        value = address;
+        value = address.trim().replaceAll(" +", " ");
     }
 
     /**

--- a/src/main/java/seedu/address/model/pet/Diet.java
+++ b/src/main/java/seedu/address/model/pet/Diet.java
@@ -16,7 +16,7 @@ public class Diet {
      */
     public Diet(String diet) {
         requireNonNull(diet);
-        value = diet;
+        value = diet.trim().replaceAll(" +", " ");
     }
 
     @Override

--- a/src/main/java/seedu/address/model/pet/Name.java
+++ b/src/main/java/seedu/address/model/pet/Name.java
@@ -41,14 +41,15 @@ public class Name implements Comparable<Name> {
 
     @Override
     public String toString() {
-        return fullName;
+        return fullName.trim();
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equalsIgnoreCase(((Name) other).fullName));
+                && fullName.replaceAll(" ", "")
+                    .equalsIgnoreCase(((Name) other).fullName.replaceAll(" ", "")));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/pet/Name.java
+++ b/src/main/java/seedu/address/model/pet/Name.java
@@ -41,7 +41,7 @@ public class Name implements Comparable<Name> {
 
     @Override
     public String toString() {
-        return fullName.trim().replaceAll(" +", " ");
+        return fullName;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/pet/Name.java
+++ b/src/main/java/seedu/address/model/pet/Name.java
@@ -28,7 +28,7 @@ public class Name implements Comparable<Name> {
     public Name(String name) {
         requireNonNull(name);
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+        fullName = name.trim().replaceAll(" +", " ");
     }
 
     /**
@@ -41,15 +41,14 @@ public class Name implements Comparable<Name> {
 
     @Override
     public String toString() {
-        return fullName.trim();
+        return fullName.trim().replaceAll(" +", " ");
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.replaceAll(" ", "")
-                    .equalsIgnoreCase(((Name) other).fullName.replaceAll(" ", "")));
+                && fullName.equalsIgnoreCase(((Name) other).fullName));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/pet/OwnerName.java
+++ b/src/main/java/seedu/address/model/pet/OwnerName.java
@@ -29,7 +29,7 @@ public class OwnerName implements Comparable<OwnerName> {
     public OwnerName(String ownerName) {
         requireNonNull(ownerName);
         checkArgument(isValidOwnerName(ownerName), MESSAGE_CONSTRAINTS);
-        value = ownerName;
+        value = ownerName.trim().replaceAll(" +", " ");
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -22,7 +22,7 @@ public class Tag {
     public Tag(String tagName) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        this.tagName = tagName.replaceAll(" +", " ");
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -28,6 +28,7 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
+    public static final String VALID_NAME_BOB_WITH_SPACES = "Bob    Choo";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_OWNER_NAME_AMY = "Sarah Lee";

--- a/src/test/java/seedu/address/model/pet/PetTest.java
+++ b/src/test/java/seedu/address/model/pet/PetTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB_WITH_SPACES;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_OWNER_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -44,10 +45,15 @@ public class PetTest {
         Pet editedBob = new PetBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
         assertTrue(BOB.isSamePet(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PetBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePet(editedBob));
+        assertTrue(BOB.isSamePet(editedBob));
+
+        // name has duplicate spaces, all other attributes same -> returns true
+        String nameWithDuplicateSpaces = VALID_NAME_BOB_WITH_SPACES;
+        editedBob = new PetBuilder(BOB).withName(nameWithDuplicateSpaces).build();
+        assertTrue(BOB.isSamePet(editedBob));
     }
 
     @Test


### PR DESCRIPTION
Remove leading, trailing and duplicate whitespaces in pet name. This is to reduce user-input error when keying in pet names.