### PR TITLE
#155 - Restrict user input for owner name and name fields

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -101,7 +101,7 @@ Format: `add n/NAME_OF_PET o/OWNER_NAME p/PHONE_NUMBER a/ADDRESS [t/BREED]...`
   * If a pet is a Golden Dachshund, you can use `t/Golden Retriever t/Dachshund` or just `t/Golden Dachshund`.
 * Each particular entered must strictly correspond to its legal prefix. e.g: `p/Address` is considered as invalid.
 * Phone number **must only contain numbers**.
-* Pet name and owner name **must only contain alphabets or spaces**.
+* `NAME_OF_PET` (pet name) and `OWNER_NAME` (owner name) **must only contain alphabets or spaces**.
 
 Examples:
 * `add n/Woofie o/Alice Tan p/98765432 a/523 Woodlands ave 5, #01-01 t/Bulldog` will show a screenshot as below.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -102,6 +102,10 @@ Format: `add n/NAME_OF_PET o/OWNER_NAME p/PHONE_NUMBER a/ADDRESS [t/BREED]...`
 * Each particular entered must strictly correspond to its legal prefix. e.g: `p/Address` is considered as invalid.
 * Phone number **must only contain numbers**.
 * `NAME_OF_PET` (pet name) and `OWNER_NAME` (owner name) **must only contain alphabets or spaces**.
+* `PHONE_NUMBER` (phone number) should be a valid Singapore phone number. It should start with **6,7,8** and should be 
+**8 digits** long.
+  * You can include an optional country code in front of the phone number. `p/+6581234567` There should be no spaces
+    between `+65` and the corresponding phone number.
 
 Examples:
 * `add n/Woofie o/Alice Tan p/98765432 a/523 Woodlands ave 5, #01-01 t/Bulldog` will show a screenshot as below.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -101,6 +101,7 @@ Format: `add n/NAME_OF_PET o/OWNER_NAME p/PHONE_NUMBER a/ADDRESS [t/BREED]...`
   * If a pet is a Golden Dachshund, you can use `t/Golden Retriever t/Dachshund` or just `t/Golden Dachshund`.
 * Each particular entered must strictly correspond to its legal prefix. e.g: `p/Address` is considered as invalid.
 * Phone number **must only contain numbers**.
+* Pet name and owner name **must only contain alphabets or spaces**.
 
 Examples:
 * `add n/Woofie o/Alice Tan p/98765432 a/523 Woodlands ave 5, #01-01 t/Bulldog` will show a screenshot as below.

--- a/src/main/java/seedu/address/model/pet/Name.java
+++ b/src/main/java/seedu/address/model/pet/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphabets and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[a-zA-Z][a-zA-Z ]+";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/pet/OwnerName.java
+++ b/src/main/java/seedu/address/model/pet/OwnerName.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class OwnerName implements Comparable<OwnerName> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Owner names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Owner names should only contain alphabets and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[a-zA-Z][a-zA-Z ]+";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/pet/Phone.java
+++ b/src/main/java/seedu/address/model/pet/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone number should start with 6,8 or 9. It should be 8 digits long. Country code is optional.";
+    public static final String VALIDATION_REGEX = "^(?:\\+65)?[689][0-9]{7}$";
     public final String value;
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPetsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPetsAddressBook.json
@@ -34,7 +34,7 @@
     "appointment" : ""
   }, {
     "name" : "Pancake",
-    "phone" : "9482224",
+    "phone" : "94822242",
     "ownerName" : "Elle Meyer",
     "address" : "michegan ave",
     "tagged" : [ ],
@@ -42,7 +42,7 @@
     "appointment" : ""
   }, {
     "name" : "Waffle",
-    "phone" : "9482427",
+    "phone" : "94824272",
     "ownerName" : "Fiona Kunz",
     "address" : "little tokyo",
     "tagged" : [ ],
@@ -50,7 +50,7 @@
     "appointment" : ""
   }, {
     "name" : "Tofu",
-    "phone" : "9482442",
+    "phone" : "94824422",
     "ownerName" : "George Best",
     "address" : "4th street",
     "tagged" : [ ],

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -33,8 +33,8 @@ public class CommandTestUtil {
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_NAME_BOB_WITH_SPACES = "Bob    Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_AMY = "81234567";
+    public static final String VALID_PHONE_BOB = "61234567";
     public static final String VALID_OWNER_NAME_AMY = "Sarah Lee";
     public static final String VALID_OWNER_NAME_BOB = "Bob Lee";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -32,7 +32,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "82345678";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_OWNERNAME = "Sarah";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/model/pet/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/pet/NameContainsKeywordsPredicateTest.java
@@ -69,7 +69,7 @@ public class NameContainsKeywordsPredicateTest {
 
         // Keywords match phone, ownerName and address, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "Alice", "Main", "Street"));
-        assertFalse(predicate.test(new PetBuilder().withName("Alix Yeo").withPhone("12345")
+        assertFalse(predicate.test(new PetBuilder().withName("Alix Yeo").withPhone("81234567")
                 .withOwnerName("Alice Yeo").withAddress("Main Street").build()));
     }
 }

--- a/src/test/java/seedu/address/model/pet/NameTest.java
+++ b/src/test/java/seedu/address/model/pet/NameTest.java
@@ -33,13 +33,13 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("12345")); // numbers only
+        assertFalse(Name.isValidName("peter the 2nd")); // alphanumeric characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("David Roger Jackson Ray Jr")); // long names
     }
 
     @Test

--- a/src/test/java/seedu/address/model/pet/OwnerNameTest.java
+++ b/src/test/java/seedu/address/model/pet/OwnerNameTest.java
@@ -33,13 +33,14 @@ public class OwnerNameTest {
         assertFalse(OwnerName.isValidOwnerName(" ")); // spaces only
         assertFalse(OwnerName.isValidOwnerName("^")); // only non-alphanumeric characters
         assertFalse(OwnerName.isValidOwnerName("peter*")); // contains non-alphanumeric characters
+        assertFalse(OwnerName.isValidOwnerName("12345")); // numbers only
+        assertFalse(OwnerName.isValidOwnerName("peter the 2nd")); // alphanumeric characters
+
 
         // valid ownerName
         assertTrue(OwnerName.isValidOwnerName("peter jack")); // alphabets only
-        assertTrue(OwnerName.isValidOwnerName("12345")); // numbers only
-        assertTrue(OwnerName.isValidOwnerName("peter the 2nd")); // alphanumeric characters
         assertTrue(OwnerName.isValidOwnerName("Capital Tan")); // with capital letters
-        assertTrue(OwnerName.isValidOwnerName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(OwnerName.isValidOwnerName("David Roger Jackson Ray Jr")); // long names
     }
 
     @Test

--- a/src/test/java/seedu/address/model/pet/PhoneTest.java
+++ b/src/test/java/seedu/address/model/pet/PhoneTest.java
@@ -31,10 +31,12 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("911")); // exactly 3 numbers
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("93121534")); // starts with 9
+        assertTrue(Phone.isValidPhone("81234567")); // starts with 8
+        assertTrue(Phone.isValidPhone("61234567")); // starts with 6
+
     }
 }

--- a/src/test/java/seedu/address/model/pet/PhoneTest.java
+++ b/src/test/java/seedu/address/model/pet/PhoneTest.java
@@ -34,6 +34,7 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("911")); // exactly 3 numbers
 
         // valid phone numbers
+        assertTrue(Phone.isValidPhone("+6585123456")); // starts with country code (+65)
         assertTrue(Phone.isValidPhone("93121534")); // starts with 9
         assertTrue(Phone.isValidPhone("81234567")); // starts with 8
         assertTrue(Phone.isValidPhone("61234567")); // starts with 6

--- a/src/test/java/seedu/address/testutil/TypicalPets.java
+++ b/src/test/java/seedu/address/testutil/TypicalPets.java
@@ -41,17 +41,17 @@ public class TypicalPets {
     public static final Pet DANIEL = new PetBuilder().withName("Peepee").withPhone("87652533")
             .withOwnerName("Daniel Meier").withAddress("10th street").withTags("friends")
             .withDiet("").withAppointment().withPresentAttendanceEntry(DATE_TODAY).build();
-    public static final Pet PANCAKE = new PetBuilder().withName("Pancake").withPhone("9482224")
+    public static final Pet PANCAKE = new PetBuilder().withName("Pancake").withPhone("94822242")
             .withOwnerName("Elle Meyer").withAddress("michegan ave").withDiet("").withAppointment().build();
-    public static final Pet WAFFLE = new PetBuilder().withName("Waffle").withPhone("9482427")
+    public static final Pet WAFFLE = new PetBuilder().withName("Waffle").withPhone("94824272")
             .withOwnerName("Fiona Kunz").withAddress("little tokyo").withDiet("").withAppointment().build();
-    public static final Pet TOFU = new PetBuilder().withName("Tofu").withPhone("9482442")
+    public static final Pet TOFU = new PetBuilder().withName("Tofu").withPhone("94824422")
             .withOwnerName("George Best").withAddress("4th street").withDiet("").withAppointment().build();
 
     // Manually added
-    public static final Pet HOON = new PetBuilder().withName("Hoon Meier").withPhone("8482424")
+    public static final Pet HOON = new PetBuilder().withName("Hoon Meier").withPhone("84824242")
             .withOwnerName("Stefan Sim").withAddress("little india").build();
-    public static final Pet IDA = new PetBuilder().withName("Ida Mueller").withPhone("8482131")
+    public static final Pet IDA = new PetBuilder().withName("Ida Mueller").withPhone("84821312")
             .withOwnerName("Han Solo").withAddress("chicago ave").build();
 
     // Manually added - Pet's details found in {@code CommandTestUtil}


### PR DESCRIPTION
Only allow users to key in alphabets and spaces for owner name and name fields. 