### PR TITLE
Fix edit command duplicate pets issue

### DIFF
--- a/src/main/java/seedu/address/model/pet/Pet.java
+++ b/src/main/java/seedu/address/model/pet/Pet.java
@@ -112,8 +112,6 @@ public class Pet {
                 && otherPet.getOwnerName().equals(getOwnerName())
                 && otherPet.getPhone().equals(getPhone())
                 && otherPet.getAddress().equals(getAddress())
-                && otherPet.getDiet().equals(getDiet())
-                && otherPet.getAppointment().equals(getAppointment())
                 && otherPet.getTags().equals(getTags());
     }
 

--- a/src/main/java/seedu/address/model/pet/Pet.java
+++ b/src/main/java/seedu/address/model/pet/Pet.java
@@ -81,8 +81,7 @@ public class Pet {
     }
 
     /**
-     * Returns true if both pets have the same name.
-     * This defines a weaker notion of equality between two pets.
+     * Returns true if both pets have the same name, owner's name, contact number and tags.
      */
     public boolean isSamePet(Pet otherPet) {
         if (otherPet == this) {
@@ -90,7 +89,10 @@ public class Pet {
         }
 
         return otherPet != null
-                && otherPet.getName().equals(getName());
+            && otherPet.getName().equals(getName())
+            && otherPet.getOwnerName().equals(getOwnerName())
+            && otherPet.getPhone().equals(getPhone())
+            && otherPet.getAddress().equals(getAddress());
     }
 
     /**
@@ -109,10 +111,9 @@ public class Pet {
 
         Pet otherPet = (Pet) other;
         return otherPet.getName().equals(getName())
-                && otherPet.getOwnerName().equals(getOwnerName())
-                && otherPet.getPhone().equals(getPhone())
-                && otherPet.getAddress().equals(getAddress())
-                && otherPet.getTags().equals(getTags());
+            && otherPet.getOwnerName().equals(getOwnerName())
+            && otherPet.getPhone().equals(getPhone())
+            && otherPet.getAddress().equals(getAddress());
     }
 
     @Override
@@ -125,16 +126,16 @@ public class Pet {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
-                .append("; OwnerName: ")
-                .append(getOwnerName())
-                .append("; Phone: ")
-                .append(getPhone())
-                .append("; Address: ")
-                .append(getAddress())
-                .append("; Diet: ")
-                .append(getDiet())
-                .append("; Appointment: ")
-                .append(getAppointment());
+            .append("; OwnerName: ")
+            .append(getOwnerName())
+            .append("; Phone: ")
+            .append(getPhone())
+            .append("; Address: ")
+            .append(getAddress())
+            .append("; Diet: ")
+            .append(getDiet())
+            .append("; Appointment: ")
+            .append(getAppointment());
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -69,6 +69,15 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_duplicatePetDifferentAppointment_throwsCommandException() {
+        Pet validPet = new PetBuilder().withAppointment("05-05-2022 09:00", "NUS Vet Clinic").build();
+        AddCommand addCommand = new AddCommand(new PetBuilder().build());
+        ModelStub modelStub = new ModelStubWithPet(validPet);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PET, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         Pet alice = new PetBuilder().withName("Alice").build();
         Pet bob = new PetBuilder().withName("Bob").build();

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,6 +51,24 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_duplicatePetDifferentTag_throwsCommandException() {
+        Pet validPet = new PetBuilder().withTags("Poodle").build();
+        AddCommand addCommand = new AddCommand(new PetBuilder().build());
+        ModelStub modelStub = new ModelStubWithPet(validPet);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PET, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_duplicatePetDifferentDiet_throwsCommandException() {
+        Pet validPet = new PetBuilder().withDiet("Vegetarian").build();
+        AddCommand addCommand = new AddCommand(new PetBuilder().build());
+        ModelStub modelStub = new ModelStubWithPet(validPet);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PET, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         Pet alice = new PetBuilder().withName("Alice").build();
         Pet bob = new PetBuilder().withName("Bob").build();

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -120,6 +120,26 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_duplicatePetDifferentTagUnfilteredList_failure() {
+        Pet firstPet = model.getFilteredPetList().get(INDEX_FIRST_PET.getZeroBased());
+        EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder(firstPet).withTags("poodle").build();
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_PET, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PET);
+    }
+
+    @Test
+    public void execute_duplicatePetDifferentTagFilteredList_failure() {
+        showPetAtIndex(model, INDEX_FIRST_PET);
+
+        Pet petInList = model.getAddressBook().getPetList().get(INDEX_SECOND_PET.getZeroBased());
+        EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder(petInList).withTags("poodle").build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PET, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PET);
+    }
+
+    @Test
     public void execute_invalidPetIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPetList().size() + 1);
         EditPetDescriptor descriptor = new EditPetDescriptorBuilder().withName(VALID_NAME_BOB).build();

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -48,7 +48,7 @@ public class AddressBookTest {
     @Test
     public void resetData_withDuplicatePets_throwsDuplicatePetException() {
         // Two pets with the same identity fields
-        Pet editedAlice = new PetBuilder(BOBA).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
+        Pet editedAlice = new PetBuilder(BOBA).withAddress(VALID_ADDRESS_BOBA).withTags(VALID_TAG_FRIEND)
                 .build();
         List<Pet> newPets = Arrays.asList(BOBA, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPets);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -3,10 +3,8 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOBA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPets.BOBA;
 import static seedu.address.testutil.TypicalPets.getTypicalAddressBook;
@@ -49,7 +47,7 @@ public class AddressBookTest {
     public void resetData_withDuplicatePets_throwsDuplicatePetException() {
         // Two pets with the same identity fields
         Pet editedAlice = new PetBuilder(BOBA).withAddress(VALID_ADDRESS_BOBA).withTags(VALID_TAG_FRIEND)
-                .build();
+            .build();
         List<Pet> newPets = Arrays.asList(BOBA, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPets);
 
@@ -76,7 +74,7 @@ public class AddressBookTest {
     public void hasPet_petWithSameIdentityFieldsInWoofAreYou_returnsTrue() {
         addressBook.addPet(BOBA);
         Pet editedAlice = new PetBuilder(BOBA).withAddress(VALID_ADDRESS_BOBA).withTags(VALID_TAG_FRIEND)
-                .build();
+            .build();
         assertTrue(addressBook.hasPet(editedAlice));
     }
 

--- a/src/test/java/seedu/address/model/pet/PetTest.java
+++ b/src/test/java/seedu/address/model/pet/PetTest.java
@@ -32,10 +32,10 @@ public class PetTest {
         // null -> returns false
         assertFalse(BOBA.isSamePet(null));
 
-        // same name, all other attributes different -> returns true
+        // same name, all other attributes different -> returns false
         Pet editedAlice = new PetBuilder(BOBA).withPhone(VALID_PHONE_BOB).withOwnerName(VALID_OWNER_NAME_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(BOBA.isSamePet(editedAlice));
+        assertFalse(BOBA.isSamePet(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new PetBuilder(BOBA).withName(VALID_NAME_BOB).build();
@@ -90,8 +90,8 @@ public class PetTest {
         editedAlice = new PetBuilder(BOBA).withAddress(VALID_ADDRESS_BOB).build();
         assertFalse(BOBA.equals(editedAlice));
 
-        // different tags -> returns false
+        // different tags -> returns true
         editedAlice = new PetBuilder(BOBA).withTags(VALID_TAG_HUSBAND).build();
-        assertFalse(BOBA.equals(editedAlice));
+        assertTrue(BOBA.equals(editedAlice));
     }
 }


### PR DESCRIPTION
Previously, users could use the edit command to "add" duplicate pets into WoofAreYou.

Let's update the `isSamePet` and `equals` methods of the `Pet` class so that such commands do not result in duplicate pets. 

Now, only pets with the same name, owner name, address and owner phone number are considered to be equal.