### PR TITLE
Restrict parse tags function

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -121,7 +121,7 @@ How the parsing works:
 
 The `Model` component,
 
-* stores the address book data i.e., all `Pet` objects (which are contained in a `UniquePetList` object).
+* stores WoofAreYou data i.e., all `Pet` objects (which are contained in a `UniquePetList` object).
 * stores the currently 'selected' `Pet` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Pet>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
@@ -140,7 +140,7 @@ The `Model` component,
 <img src="images/StorageClassDiagram.png" width="550" />
 
 The `Storage` component,
-* can save both address book data and user preference data in json format, and read them back into corresponding objects.
+* can save both WoofAreYou data and user preference data in json format, and read them back into corresponding objects.
 * inherits from both `AddressBookStorage` and `UserPrefStorage`, which means it can be treated as either one (if only the functionality of only one is needed).
 * depends on some classes in the `Model` component (because the `Storage` component's job is to save/retrieve objects that belong to the `Model`)
 
@@ -159,7 +159,7 @@ This section describes some noteworthy details on how certain features are imple
 #### Proposed Implementation
 
 The proposed sorting mechanism is facilitated by `SortCommand` class. It extends `Command`
-and takes in a field that the user wishes to sort the Address Book by. The field is parsed by
+and takes in a field that the user wishes to sort WoofAreYou by. The field is parsed by
 `SortCommandParser`.
 
 The primary sorting operation that takes place in the SortCommand class is sortPetList. This operation is exposed
@@ -260,11 +260,11 @@ by the prefixes / augments.
 
 #### Proposed Implementation
 The proposed filter mechanism is facilitated by `FilterCommand` class.
-It extends `Command` and takes in a field that the user wishes to filter the Address Book by followed by
+It extends `Command` and takes in a field that the user wishes to filter WoofAreYou by followed by
 a given filter word. The field is parsed by `FilterCommandParser`. A filter word will follow after the keyword to
 indicate what the user wants to filter out specifically.
 
-Currently, pet list can be filtered by date, owner name and tag. Users can only filter the address book by one field at
+Currently, pet list can be filtered by date, owner name and tag. Users can only filter WoofAreYou by one field at
 a time only. `FilterCommandParser` ensure this by throwing a `ParseException` when more than one filter field is
 entered.
 
@@ -274,13 +274,13 @@ Each class extends the `FilterByContainsFilterWordPredicate` class, which implem
 in order for `FindCommand` to handle different fields appropriately and consequently test each pet differently for a
 match in the specified field.
 
-`FindCommand` then updates the address book using one of the three classes (`Predicates`). Each class has a different
+`FindCommand` then updates WoofAreYou using one of the three classes (`Predicates`). Each class has a different
 way of testing `Pet`. If user filters by date, test will go through attendance of pet and determines if pet is present
 on the specified date (entered as `filterWord` by user). If user filters by owner name, test will go through owner name
-of pet and finds a partial/ full match with `filterWord` provided. Similarly, if user filters by tags, test will go
-through tags of pet and find match with `filterWord` provided.
+of pet and finds a partial/ full match with `filterWord` provided. Similarly, if user filters by tag, test will go
+through the tag of the pets and find a match using the `filterWord` provided.
 
-The following sequence diagram shows how the filter operation works when `filter byTags/ beagle` is called:
+The following sequence diagram shows how the filter operation works when `filter byTag/ beagle` is called:
 
 ![FilterSequenceDiagram](images/FilterSequenceDiagram.png)
 
@@ -305,31 +305,31 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 The proposed undo/redo mechanism is facilitated by `VersionedAddressBook`. It extends `AddressBook` with an undo/redo history, stored internally as an `addressBookStateList` and `currentStatePointer`. Additionally, it implements the following operations:
 
-* `VersionedAddressBook#commit()` — Saves the current address book state in its history.
-* `VersionedAddressBook#undo()` — Restores the previous address book state from its history.
-* `VersionedAddressBook#redo()` — Restores a previously undone address book state from its history.
+* `VersionedAddressBook#commit()` — Saves the current WoofAreYou state in its history.
+* `VersionedAddressBook#undo()` — Restores the previous WoofAreYou state from its history.
+* `VersionedAddressBook#redo()` — Restores a previously undone WoofAreYou state from its history.
 
 These operations are exposed in the `Model` interface as `Model#commitAddressBook()`, `Model#undoAddressBook()` and `Model#redoAddressBook()` respectively.
 
 Given below is an example usage scenario and how the undo/redo mechanism behaves at each step.
 
-Step 1. The user launches the application for the first time. The `VersionedAddressBook` will be initialized with the initial address book state, and the `currentStatePointer` pointing to that single address book state.
+Step 1. The user launches the application for the first time. The `VersionedAddressBook` will be initialized with the initial WoofAreYou state, and the `currentStatePointer` pointing to that single WoofAreYou state.
 
 ![UndoRedoState0](images/UndoRedoState0.png)
 
-Step 2. The user executes `delete 5` command to delete the 5th pet in the address book. The `delete` command calls `Model#commitAddressBook()`, causing the modified state of the address book after the `delete 5` command executes to be saved in the `addressBookStateList`, and the `currentStatePointer` is shifted to the newly inserted address book state.
+Step 2. The user executes `delete 5` command to delete the 5th pet in WoofAreYou. The `delete` command calls `Model#commitAddressBook()`, causing the modified state of WoofAreYou after the `delete 5` command executes to be saved in the `addressBookStateList`, and the `currentStatePointer` is shifted to the newly inserted WoofAreYou state.
 
 ![UndoRedoState1](images/UndoRedoState1.png)
 
-Step 3. The user executes `add n/David …​` to add a new pet. The `add` command also calls `Model#commitAddressBook()`, causing another modified address book state to be saved into the `addressBookStateList`.
+Step 3. The user executes `add n/David …​` to add a new pet. The `add` command also calls `Model#commitAddressBook()`, causing another modified WoofAreYou state to be saved into the `addressBookStateList`.
 
 ![UndoRedoState2](images/UndoRedoState2.png)
 
-<div markdown="span" class="alert alert-info">:information_source: **Note:** If a command fails its execution, it will not call `Model#commitAddressBook()`, so the address book state will not be saved into the `addressBookStateList`.
+<div markdown="span" class="alert alert-info">:information_source: **Note:** If a command fails its execution, it will not call `Model#commitAddressBook()`, so the WoofAreYou state will not be saved into the `addressBookStateList`.
 
 </div>
 
-Step 4. The user now decides that adding the pet was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous address book state, and restores the address book to that state.
+Step 4. The user now decides that adding the pet was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous WoofAreYou state, and restores the WoofAreYou to that state.
 
 ![UndoRedoState3](images/UndoRedoState3.png)
 
@@ -346,17 +346,17 @@ The following sequence diagram shows how the undo operation works:
 
 </div>
 
-The `redo` command does the opposite — it calls `Model#redoAddressBook()`, which shifts the `currentStatePointer` once to the right, pointing to the previously undone state, and restores the address book to that state.
+The `redo` command does the opposite — it calls `Model#redoAddressBook()`, which shifts the `currentStatePointer` once to the right, pointing to the previously undone state, and restores WoofAreYou to that state.
 
-<div markdown="span" class="alert alert-info">:information_source: **Note:** If the `currentStatePointer` is at index `addressBookStateList.size() - 1`, pointing to the latest address book state, then there are no undone AddressBook states to restore. The `redo` command uses `Model#canRedoAddressBook()` to check if this is the case. If so, it will return an error to the user rather than attempting to perform the redo.
+<div markdown="span" class="alert alert-info">:information_source: **Note:** If the `currentStatePointer` is at index `addressBookStateList.size() - 1`, pointing to the latest WoofAreYou state, then there are no undone AddressBook states to restore. The `redo` command uses `Model#canRedoAddressBook()` to check if this is the case. If so, it will return an error to the user rather than attempting to perform the redo.
 
 </div>
 
-Step 5. The user then decides to execute the command `list`. Commands that do not modify the address book, such as `list`, will usually not call `Model#commitAddressBook()`, `Model#undoAddressBook()` or `Model#redoAddressBook()`. Thus, the `addressBookStateList` remains unchanged.
+Step 5. The user then decides to execute the command `list`. Commands that do not modify WoofAreYou, such as `list`, will usually not call `Model#commitAddressBook()`, `Model#undoAddressBook()` or `Model#redoAddressBook()`. Thus, the `addressBookStateList` remains unchanged.
 
 ![UndoRedoState4](images/UndoRedoState4.png)
 
-Step 6. The user executes `clear`, which calls `Model#commitAddressBook()`. Since the `currentStatePointer` is not pointing at the end of the `addressBookStateList`, all address book states after the `currentStatePointer` will be purged. Reason: It no longer makes sense to redo the `add n/David …​` command. This is the behavior that most modern desktop applications follow.
+Step 6. The user executes `clear`, which calls `Model#commitAddressBook()`. Since the `currentStatePointer` is not pointing at the end of the `addressBookStateList`, all WoofAreYou states after the `currentStatePointer` will be purged. Reason: It no longer makes sense to redo the `add n/David …​` command. This is the behavior that most modern desktop applications follow.
 
 ![UndoRedoState5](images/UndoRedoState5.png)
 
@@ -368,7 +368,7 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 **Aspect: How undo & redo executes:**
 
-* **Alternative 1 (current choice):** Saves the entire address book.
+* **Alternative 1 (current choice):** Saves the entirety of WoofAreYou.
   * Pros: Easy to implement.
   * Cons: May have performance issues in terms of memory usage.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -102,7 +102,8 @@ When you receive a new pet in the daycare, you may wish to add them to WoofAreYo
 Format: `add n/NAME_OF_PET o/OWNER_NAME p/PHONE_NUMBER a/ADDRESS [t/BREED]...`
 * Each particular field is compulsory except for `BREED`.
 * `BREED` is an optional field which could be used to indicate the breed of a pet.
-  * If a pet is a Golden Dachshund, you can use `t/Golden Retriever t/Dachshund` or just `t/Golden Dachshund`.
+  * You should only be able to add *one* breed for a pet.
+  * Entering more than *one* breed will throw an error.
 * Each particular entered must strictly correspond to its legal prefix. e.g: `p/Address` is considered as invalid.
 * Phone number **must only contain numbers**.
 * `NAME_OF_PET` (pet name) and `OWNER_NAME` (owner name) **must only contain alphabets or spaces**.
@@ -130,14 +131,16 @@ Format: `edit INDEX [n/NAME_OF_PET] [o/OWNER_NAME] [p/PHONE_NUMBER] [a/ADDRESS] 
 
 **:information_source: Notes about editing `[t/BREED]`:**<br>
 
-* When editing `[t/BREED]`, the existing breed(s) of the pet will be removed.
+* When editing `[t/BREED]`, the existing breed of the pet will be removed.
+* You can only edit *one* breed. 
 * Following from the previous e.g., if you key in `edit 1 t/German Sheppard`, Woofie's "Bulldog" breed will be replaced
 by "German Sheppard" instead.
 * You can also remove all the breeds associated to the pet by typing `t/` without specifying any breed after it.
 </div>
 
 Examples:
-* Continuing from the previous example, `edit 1 o/Pauline Tan t/German Sheppard` will change the owner's name and the tag of Woofie from 'Bulldog' to 'German Sheppard'.
+* Continuing from the previous example, `edit 1 o/Pauline Tan t/German Sheppard` will change the owner's name and 
+  the tag of Woofie from 'Bulldog' to 'German Sheppard'.
 
 ### Mark a pet as present: `present`
 
@@ -320,7 +323,8 @@ life easier when using the features previously introduced.
 
 ### Find pet details: `find`
 
-In the event that you wish to search for particular pets in WoofAreYou to check up on details, and know their names, you can use this function to find pets with a particular name.
+In the event that you wish to search for particular pets in WoofAreYou to check up on details, and know their names,
+you can use this function to find pets with a particular name.
 
 If there are multiple pets with the same name, all such pets will be displayed.
 
@@ -380,7 +384,7 @@ If you just want to know common information about some pets, you can filter the 
 Format: `filter f/KEYWORD`
 
 * **One and only one** filter parameter is to be used with this command.
-* Specified `f/` only consists of: `byDate/`, `byApp/`, `byTags/` and `byOwner/`.
+* Specified `f/` only consists of: `byDate/`, `byApp/`, `byTag/` and `byOwner/`.
 * If you use `byDate/` or `byApp/`, `KEYWORD` has to be in `dd-MM-yyyy` format, or `today`.
 * If you use `byOwner/`, `KEYWORD` can be any length.
 * If you use `byTag/`, `KEYWORD` can be any length.
@@ -388,7 +392,7 @@ Format: `filter f/KEYWORD`
 
 Examples:
 * `filter byOwner/Lily` shows pets owned by all Lily(s).
-* `filter byTag/Retriever` shows pets with `Retriever` in their tags.
+* `filter byTag/Retriever` shows pets with `Retriever` in their tag.
 * `filter byDate/30-03-2022` show pets present on 30 March 2022 as shown below.
 
 <p align="center">
@@ -415,7 +419,7 @@ Format: `undo`
 </div>
 
 Examples:
-* If the user chooses to delete a pet, `undo` will revert the address book to the state where the pet is not deleted.
+* If the user chooses to delete a pet, `undo` will revert the WoofAreYou to the state where the pet is not deleted.
 
 ### View help : `help`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -375,7 +375,7 @@ If you just want to know common information about some pets, you can filter the 
 * You can filter by date, to find out which pets are present on a given date.
 * You can filter by appointment, to find out which pets have appointments on a given date.
 * You can filter by owner's name, to find all pets with the same owner.
-* You can also filter by tags, to find all pets of a common breed.
+* You can also filter by tag, to find all pets of a common breed.
 
 Format: `filter f/KEYWORD`
 
@@ -383,12 +383,12 @@ Format: `filter f/KEYWORD`
 * Specified `f/` only consists of: `byDate/`, `byApp/`, `byTags/` and `byOwner/`.
 * If you use `byDate/` or `byApp/`, `KEYWORD` has to be in `dd-MM-yyyy` format, or `today`.
 * If you use `byOwner/`, `KEYWORD` can be any length.
-* If you use `byTags/`, `KEYWORD` can be any length.
+* If you use `byTag/`, `KEYWORD` can be any length.
     * Can filter with a partial match in `Keyword`: `Bord`, `Borde Colli`, will match with pets tagged as `Border Collie`
 
 Examples:
 * `filter byOwner/Lily` shows pets owned by all Lily(s).
-* `filter byTags/Retriever` shows pets with `Retriever` in their tags.
+* `filter byTag/Retriever` shows pets with `Retriever` in their tags.
 * `filter byDate/30-03-2022` show pets present on 30 March 2022 as shown below.
 
 <p align="center">

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,6 +85,9 @@ categorised into **Basic Administration**, **Optional Requirements** and **Effic
 
 * If a parameter is expected only once in the command but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
   e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
+  
+* However, for the tag parameter, users will only be able to key in one tag. 
+  e.g. if you specify `t/Golden t/Retriever`, an error message will be shown.
 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.

--- a/src/main/java/seedu/address/commons/util/FilterUtil.java
+++ b/src/main/java/seedu/address/commons/util/FilterUtil.java
@@ -53,7 +53,7 @@ public class FilterUtil {
         if (predicate instanceof DateContainsFilterDatePredicate) {
             return "date";
         } else if (predicate instanceof TagContainsFilterWordPredicate) {
-            return "tags";
+            return "breed";
         } else if (predicate instanceof OwnerNameContainsFilterWordPredicate) {
             return "owner's name";
         } else {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -24,7 +24,7 @@ public class AddCommand extends Command {
             + PREFIX_OWNER_NAME + "OWNER_NAME "
             + PREFIX_PHONE + "PHONE_NUMBER "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "BREED]"
+            + "[" + PREFIX_TAG + "BREED] ... \n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Pee Pee "
             + PREFIX_OWNER_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.pet.Pet;
 
 /**
- * Adds a pet to the address book.
+ * Adds a pet to WoofAreYou.
  */
 public class AddCommand extends Command {
 
@@ -24,7 +24,7 @@ public class AddCommand extends Command {
             + PREFIX_OWNER_NAME + "OWNER_NAME "
             + PREFIX_PHONE + "PHONE_NUMBER "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "BREED]...\n"
+            + "[" + PREFIX_TAG + "BREED]"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Pee Pee "
             + PREFIX_OWNER_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/commands/AppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AppointmentCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.pet.Pet;
 
 
 /**
- * Adds appointment details to a pet identified using it's displayed index from the address book.
+ * Adds appointment details to a pet identified using it's displayed index from WoofAreYou.
  */
 public class AppointmentCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ChargeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ChargeCommand.java
@@ -20,7 +20,7 @@ import seedu.address.model.pet.Pet;
 
 
 /**
- * Computes a month's charge of a pet identified using it's displayed index from the address book.
+ * Computes a month's charge of a pet identified using it's displayed index from WoofAreYou.
  */
 public class ChargeCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -6,7 +6,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Clears WoofAreYou.
  */
 public class ClearCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
 import seedu.address.model.pet.Pet;
 
 /**
- * Deletes a pet identified using it's displayed index from the address book.
+ * Deletes a pet identified using it's displayed index from WoofAreYou.
  */
 public class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DietCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DietCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.pet.Pet;
 
 
 /**
- * Adds diet details to a pet identified using its displayed index from the address book.
+ * Adds diet details to a pet identified using its displayed index from WoofAreYou.
  */
 public class DietCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -43,7 +43,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_OWNER_NAME + "OWNERNAME] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "BREED]"
+            + "[" + PREFIX_TAG + "BREED] ... \n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_OWNER_NAME + "johndoe";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -43,7 +43,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_OWNER_NAME + "OWNERNAME] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "BREED]"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_OWNER_NAME + "johndoe";

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import seedu.address.model.Model;
 
 /**
- * Terminates the program.
+ * Terminates WoofAreYou.
  */
 public class ExitCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.Model;
 import seedu.address.model.filter.FilterByContainsFilterWordPredicate;
 
 /**
- * Filters all pets in address book by field provided.
+ * Filters all pets in WoofAreYou based on the field provided by the pet owner.
  * Filter word matching is case-insensitive.
  * Fields can only be from a defined set.
  */

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -7,7 +7,7 @@ import seedu.address.model.Model;
 import seedu.address.model.pet.NameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all pets in address book whose name contains any of the argument keywords.
+ * Finds and lists all pets in WoofAreYou whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.model.Model;
 
 /**
- * Lists all pets in the address book to the user.
+ * Lists all pets in WoofAreYou to the pet owner.
  */
 public class ListCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.model.Model;
 
+/**
+ * Sorts pets in WoofAreYou based on field indicated by the pet owner.
+ */
 public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
     public static final String MESSAGE_SUCCESS = "Sorted all pets by ";

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -7,7 +7,9 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 
-
+/**
+ * Undoes pet owner's previous commands in WoofAreYou.
+ */
 public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
     public static final String MESSAGE_SUCCESS = "Undid previous command!";

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -21,7 +21,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_CHARGE_MONTH_YEAR = new Prefix("m/");
     public static final Prefix PREFIX_CHARGE = new Prefix("c/");
     public static final Prefix PREFIX_FILTER_BY_DATE = new Prefix("byDate/");
-    public static final Prefix PREFIX_FILTER_BY_TAGS = new Prefix("byTags/");
+    public static final Prefix PREFIX_FILTER_BY_TAG = new Prefix("byTag/");
     public static final Prefix PREFIX_FILTER_BY_OWNER_NAME = new Prefix("byOwner/");
     public static final Prefix PREFIX_FILTER_BY_APPOINTMENT = new Prefix("byApp/");
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -6,7 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_BY_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_BY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_BY_OWNER_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_BY_TAGS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_BY_TAG;
 
 import seedu.address.commons.util.FilterUtil;
 import seedu.address.logic.commands.FilterCommand;
@@ -41,14 +41,14 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
 
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_FILTER_BY_DATE, PREFIX_FILTER_BY_TAGS,
+                ArgumentTokenizer.tokenize(args, PREFIX_FILTER_BY_DATE, PREFIX_FILTER_BY_TAG,
                         PREFIX_FILTER_BY_OWNER_NAME, PREFIX_FILTER_BY_APPOINTMENT);
 
         String keyword = ParserUtil.parseFilterArgs(trimmedArgs);
 
         if (argMultimap.getValue(PREFIX_FILTER_BY_DATE).isPresent()) {
             return new FilterCommand(new DateContainsFilterDatePredicate(keyword));
-        } else if (argMultimap.getValue(PREFIX_FILTER_BY_TAGS).isPresent()) {
+        } else if (argMultimap.getValue(PREFIX_FILTER_BY_TAG).isPresent()) {
             return new FilterCommand(new TagContainsFilterWordPredicate(keyword));
         } else if (argMultimap.getValue(PREFIX_FILTER_BY_OWNER_NAME).isPresent()) {
             return new FilterCommand(new OwnerNameContainsFilterWordPredicate(keyword));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -38,6 +38,8 @@ public class ParserUtil {
         "Pick up time should be valid and in HH:mm format!";
     public static final String MESSAGE_INVALID_DROPOFF_TIME =
         "Drop off time should be valid and in HH:mm format!";
+    public static final String MESSAGE_INVALID_NUMBER_OF_TAGS =
+            "User should only be able to key in one tag!";
 
 
     /**
@@ -149,6 +151,9 @@ public class ParserUtil {
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
+        if (tags.size() > 1) {
+            throw new ParseException(MESSAGE_INVALID_NUMBER_OF_TAGS);
+        }
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
             tagSet.add(parseTag(tagName));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -151,13 +151,17 @@ public class ParserUtil {
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
+
+        // Strictly only allow one tag.
         if (tags.size() > 1) {
             throw new ParseException(MESSAGE_INVALID_NUMBER_OF_TAGS);
         }
+
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
             tagSet.add(parseTag(tagName));
         }
+
         return tagSet;
     }
 

--- a/src/main/java/seedu/address/model/pet/Pet.java
+++ b/src/main/java/seedu/address/model/pet/Pet.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import seedu.address.model.tag.Tag;
 
 /**
- * Represents a Pet in the address book.
+ * Represents a Pet in WoofAreYou.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Pet {
@@ -139,7 +139,7 @@ public class Pet {
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
-            builder.append("; Tags: ");
+            builder.append("; Tag: ");
             tags.forEach(builder::append);
         }
         return builder.toString();

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,6 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_SIZE_CONSTRAINTS = "User should only be able to key in one tag!";
     public static final String VALIDATION_REGEX = "\\s*\\p{Alnum}[\\p{Alnum}\\s]*";
 
     public final String tagName;

--- a/src/test/java/seedu/address/commons/util/FilterUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/FilterUtilTest.java
@@ -63,7 +63,7 @@ public class FilterUtilTest {
         assertEquals("date", FilterUtil.successMessageMatch(datePredicate));
         assertEquals("appointment date", FilterUtil.successMessageMatch(appPredicate));
         assertEquals("owner's name", FilterUtil.successMessageMatch(ownerPredicate));
-        assertEquals("tags", FilterUtil.successMessageMatch(tagPredicate));
+        assertEquals("breed", FilterUtil.successMessageMatch(tagPredicate));
     }
 
     //---------------- Tests for tagContainsFilterWord --------------------------------------

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -128,10 +128,10 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPetDescriptorBuilder().withName(VALID_NAME_AMY)
             .withPhone(VALID_PHONE_AMY).withOwnerName(VALID_OWNER_NAME_AMY).withAddress(VALID_ADDRESS_AMY)
-            .withTags(VALID_TAG_FRIEND).build();
+            .withTag(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPetDescriptorBuilder().withName(VALID_NAME_BOB)
             .withPhone(VALID_PHONE_BOB).withOwnerName(VALID_OWNER_NAME_BOB).withAddress(VALID_ADDRESS_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            .withTag(VALID_TAG_HUSBAND).build();
         PRESENT_DESC_WITH_TRANSPORT_AMY = new PresentAttendanceDescriptorBuilder()
             .withDate("2022-03-27").withPickUpTime("09:00").withDropOffTime("17:30")
             .build();

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -58,7 +58,7 @@ public class EditCommandTest {
                 .withTags(VALID_TAG_HUSBAND).build();
 
         EditPetDescriptor descriptor = new EditPetDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withPhone(VALID_PHONE_BOB).withTag(VALID_TAG_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastPet, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PET_SUCCESS, editedPet);
@@ -123,7 +123,7 @@ public class EditCommandTest {
     @Test
     public void execute_duplicatePetDifferentTagUnfilteredList_failure() {
         Pet firstPet = model.getFilteredPetList().get(INDEX_FIRST_PET.getZeroBased());
-        EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder(firstPet).withTags("poodle").build();
+        EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder(firstPet).withTag("poodle").build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PET, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PET);
@@ -134,7 +134,7 @@ public class EditCommandTest {
         showPetAtIndex(model, INDEX_FIRST_PET);
 
         Pet petInList = model.getAddressBook().getPetList().get(INDEX_SECOND_PET.getZeroBased());
-        EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder(petInList).withTags("poodle").build();
+        EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder(petInList).withTag("poodle").build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PET, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PET);

--- a/src/test/java/seedu/address/logic/commands/EditPetDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPetDescriptorTest.java
@@ -52,7 +52,7 @@ public class EditPetDescriptorTest {
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditPetDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        editedAmy = new EditPetDescriptorBuilder(DESC_AMY).withTag(VALID_TAG_HUSBAND).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -66,12 +66,6 @@ public class AddCommandParserTest {
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB + ADDRESS_DESC_AMY
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPet));
-
-        // multiple tags - all accepted
-        Pet expectedPetMultipleTags = new PetBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPetMultipleTags));
     }
 
     @Test
@@ -111,23 +105,27 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + OWNER_NAME_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_OWNER_NAME_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, OwnerName.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND, OwnerName.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND, Address.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+
+        // invalid number of tags
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Tag.MESSAGE_SIZE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB + INVALID_ADDRESS_DESC,
@@ -135,7 +133,7 @@ public class AddCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + OWNER_NAME_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -23,7 +23,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_OWNER_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPets.AMY;

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -118,7 +118,7 @@ public class EditCommandParserTest {
 
         EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withOwnerName(VALID_OWNER_NAME_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_HUSBAND).build();
+                .withTag(VALID_TAG_HUSBAND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -165,7 +165,7 @@ public class EditCommandParserTest {
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditPetDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        descriptor = new EditPetDescriptorBuilder().withTag(VALID_TAG_FRIEND).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -181,7 +181,7 @@ public class EditCommandParserTest {
                 .withPhone(VALID_PHONE_BOB)
                 .withOwnerName(VALID_OWNER_NAME_BOB)
                 .withAddress(VALID_ADDRESS_BOB)
-                .withTags(VALID_TAG_FRIEND)
+                .withTag(VALID_TAG_FRIEND)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -211,7 +211,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PET;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
-        EditPetDescriptor descriptor = new EditPetDescriptorBuilder().withTags().build();
+        EditPetDescriptor descriptor = new EditPetDescriptorBuilder().withTag().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -81,12 +81,20 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
+
         // invalid ownerName
         assertParseFailure(parser, "1" + INVALID_OWNER_NAME_DESC, OwnerName.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+
+        // invalid number of tags
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_SIZE_CONSTRAINTS);
+
+        // invalid tag
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
 
         // invalid phone followed by valid ownerName
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + OWNER_NAME_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
@@ -95,14 +103,6 @@ public class EditCommandParserTest {
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + PHONE_DESC_BOB + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Pet} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
-                Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
-                Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
-                Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_OWNER_NAME_DESC + VALID_ADDRESS_AMY
@@ -114,11 +114,11 @@ public class EditCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PET;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + OWNER_NAME_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+                + OWNER_NAME_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY;
 
         EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withOwnerName(VALID_OWNER_NAME_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_HUSBAND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -174,14 +174,14 @@ public class EditCommandParserTest {
     public void parse_multipleRepeatedFields_acceptsLast() {
         Index targetIndex = INDEX_FIRST_PET;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + OWNER_NAME_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + OWNER_NAME_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + OWNER_NAME_DESC_BOB + TAG_DESC_HUSBAND;
+                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + OWNER_NAME_DESC_AMY + PHONE_DESC_BOB
+                + ADDRESS_DESC_BOB + OWNER_NAME_DESC_BOB;
 
         EditCommand.EditPetDescriptor descriptor = new EditPetDescriptorBuilder()
                 .withPhone(VALID_PHONE_BOB)
                 .withOwnerName(VALID_OWNER_NAME_BOB)
                 .withAddress(VALID_ADDRESS_BOB)
-                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                .withTags(VALID_TAG_FRIEND)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -55,8 +55,15 @@ public class FilterCommandParserTest {
     @Test
     public void parse_validTagArg_returnsFilterCommand() {
         FilterCommand expectedFilterCommand =
-                new FilterCommand(new TagContainsFilterWordPredicate("ABC DEF"));
-        assertParseSuccess(parser, " byTags/ABC DEF", expectedFilterCommand);
+                new FilterCommand(new TagContainsFilterWordPredicate("ABC"));
+        assertParseSuccess(parser, " byTag/ABC", expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_validTagArgs_returnsFilterCommand() {
+        FilterCommand expectedFilterCommand =
+                new FilterCommand(new TagContainsFilterWordPredicate("ABC EFG"));
+        assertParseSuccess(parser, " byTag/ABC EFG", expectedFilterCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PET;
@@ -13,10 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PET;
@@ -185,6 +188,11 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTag_multipleTags_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTag(TAG_DESC_FRIEND + TAG_DESC_HUSBAND));
+    }
+
+    @Test
     public void parseTag_validValueWithoutWhitespace_returnsTag() throws Exception {
         Tag expectedTag = new Tag(VALID_TAG_1);
         assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG_1));
@@ -203,21 +211,13 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTags_collectionWithInvalidTags_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG)));
+    public void parseTags_collectionWithInvalidTag_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Collections.singletonList(INVALID_TAG)));
     }
 
     @Test
     public void parseTags_emptyCollection_returnsEmptySet() throws Exception {
         assertTrue(ParserUtil.parseTags(Collections.emptyList()).isEmpty());
-    }
-
-    @Test
-    public void parseTags_collectionWithValidTags_returnsTagSet() throws Exception {
-        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
-        Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
-
-        assertEquals(expectedTagSet, actualTagSet);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditPetDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPetDescriptorBuilder.java
@@ -79,7 +79,7 @@ public class EditPetDescriptorBuilder {
      * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditPetDescriptor}
      * that we are building.
      */
-    public EditPetDescriptorBuilder withTags(String... tags) {
+    public EditPetDescriptorBuilder withTag(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
         return this;


### PR DESCRIPTION
- Restrict the parse_tags function in `ParserUtil.java` to only accept one tag from the user. 
- Update dependencies. 
- Update documentation.
- Update documentation references of `AddressBook` to `WoofAreYou`
